### PR TITLE
Support multi-selection data stream parameters

### DIFF
--- a/Sources/FlexiBLE/bluetooth/DataStreamHandler.swift
+++ b/Sources/FlexiBLE/bluetooth/DataStreamHandler.swift
@@ -177,7 +177,7 @@ extension FXBDataStreamConfig {
             _data = data[self.byteStart..<self.byteEnd]
         }
         
-        switch self.type {
+        switch self.dataType {
         case .float: return Float(0)
         case .unsignedInt:
             var val : UInt = 0
@@ -204,7 +204,7 @@ extension FXBDataStreamConfig {
         
         var data: Data = Data()
         
-        switch self.type {
+        switch self.dataType {
         case .float:
             switch self.size {
             case 2:

--- a/Sources/FlexiBLE/bluetooth/FXBConfigValue.swift
+++ b/Sources/FlexiBLE/bluetooth/FXBConfigValue.swift
@@ -27,7 +27,7 @@ public class FXBConfigValue: ObservableObject {
     }
     
     func load(from data: Data) {
-        switch def.type {
+        switch def.dataType {
         case .float: break
         case .int:
             var val : Int = 0

--- a/Sources/FlexiBLE/spec/FXBDataStreamConfig.swift
+++ b/Sources/FlexiBLE/spec/FXBDataStreamConfig.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 
+public enum FXBConfigSelectionType: String, Codable {
+    case single = "single"
+    case range = "range"
+    case bitEncodedMultiSelect = "bit-encoded-multi"
+}
+
 public struct FXBDataStreamConfig: Codable {
     public let name: String
     public let description: String
@@ -15,7 +21,8 @@ public struct FXBDataStreamConfig: Codable {
     internal let byteStart: Int
     internal let byteEnd: Int
     internal let size: Int
-    internal let type: FXBDataValueType
+    internal let dataType: FXBDataValueType
+    public let selectionType: FXBConfigSelectionType
     public let unit: String?
     
     public let options: [AEDataStreamConfigOption]?


### PR DESCRIPTION
Support for selection types of data stream parameters: `range`, `single`, and `bit-encoded-multi`. `bit-encoded-multi` uses bit encoding to allows multiple option selections in a single configuration value.

```json
{
                            "name": "multiselect-example",
                            "description": "a dummy parameter for multiselection",
                            "byte_start": 3,
                            "byte_end": 4,
                            "size": 2,
                            "data_type": "uint",
                            "selection_type": "bit-encoded-multi",
                            "unit": "Hz",
                            "options": [
                                {
                                    "name": "option1",
                                    "description": "option1",
                                    "value": "1"
                                },
                                {
                                    "name": "option2",
                                    "description": "option2",
                                    "value": "2"
                                },
                                {
                                    "name": "option3",
                                    "description": "option3",
                                    "value": "4"
                                },
                                {
                                    "name": "option4",
                                    "description": "option3",
                                    "value": "8"
                                },
                                {
                                    "name": "option5",
                                    "description": "option3",
                                    "value": "16"
                                },
                                {
                                    "name": "option6",
                                    "description": "option3",
                                    "value": "32"
                                }
                            ],
                            "default_value": "16",
                            "range": null
                        }
                    ],
```