### PR TITLE
InfluxDB continuous upload

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,39 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "CSV.swift",
-        "repositoryURL": "https://github.com/yaslab/CSV.swift",
-        "state": {
-          "branch": null,
-          "revision": "81d2874c51db364d7e1d71b0d99018a294c87ac1",
-          "version": "2.4.3"
-        }
-      },
-      {
         "package": "GRDB",
         "repositoryURL": "https://github.com/groue/GRDB.swift.git",
         "state": {
           "branch": "master",
-          "revision": "9b0e41ad586d4a52d67143a73732e99e38c29d86",
+          "revision": "c3cc998fc14efa356259e5d01d8910e82de080ad",
           "version": null
-        }
-      },
-      {
-        "package": "Gzip",
-        "repositoryURL": "https://github.com/1024jp/GzipSwift",
-        "state": {
-          "branch": null,
-          "revision": "ba0b6cb51cc6202f896e469b87d2889a46b10d1b",
-          "version": "5.1.1"
-        }
-      },
-      {
-        "package": "influxdb-client-swift",
-        "repositoryURL": "https://github.com/influxdata/influxdb-client-swift",
-        "state": {
-          "branch": null,
-          "revision": "4948e6e2100e27bfe4233e6be9fae72175d2dbe1",
-          "version": "1.1.0"
         }
       }
     ]

--- a/Sources/FlexiBLE/db/FXBWrite.swift
+++ b/Sources/FlexiBLE/db/FXBWrite.swift
@@ -72,6 +72,25 @@ public struct FXBWrite {
         }
     }
     
+    // MARK: - Device Upload
+    public func recordUpload(success: Bool, byteSize: Int, numberOfRecords: Int, bucket: String?, measurement: String?, errorMessage: String?) async throws -> Int64 {
+        
+        return try await dbMgr.dbQueue.write { (db) -> Int64 in
+            var rec = FXBDataUpload(
+                status: .success,
+                ts: Date.now,
+                byteSize: byteSize,
+                numberOfRecords: numberOfRecords,
+                bucket: bucket,
+                measurement: measurement,
+                errorMessage: errorMessage
+            )
+            
+            try rec.insert(db)
+            return rec.id!
+        }
+    }
+    
     //MARK: - Device Spec
     public func recordSpec(_ spec: FXBSpec) async throws -> Int64 {
         let externalId = spec.id

--- a/Sources/FlexiBLE/db/FXBWrite.swift
+++ b/Sources/FlexiBLE/db/FXBWrite.swift
@@ -72,25 +72,6 @@ public struct FXBWrite {
         }
     }
     
-    // MARK: - Device Upload
-    public func recordUpload(success: Bool, byteSize: Int, numberOfRecords: Int, bucket: String?, measurement: String?, errorMessage: String?) async throws -> Int64 {
-        
-        return try await dbMgr.dbQueue.write { (db) -> Int64 in
-            var rec = FXBDataUpload(
-                status: .success,
-                ts: Date.now,
-                byteSize: byteSize,
-                numberOfRecords: numberOfRecords,
-                bucket: bucket,
-                measurement: measurement,
-                errorMessage: errorMessage
-            )
-            
-            try rec.insert(db)
-            return rec.id!
-        }
-    }
-    
     //MARK: - Device Spec
     public func recordSpec(_ spec: FXBSpec) async throws -> Int64 {
         let externalId = spec.id

--- a/Sources/FlexiBLE/db/tables/FXBDataUpload.swift
+++ b/Sources/FlexiBLE/db/tables/FXBDataUpload.swift
@@ -16,8 +16,8 @@ internal enum FXBDataUploadStatus: String, Codable {
 internal struct FXBDataUpload: Codable {
     var id: Int64?
     var status: FXBDataUploadStatus
-    var createdAt: Date
-    var duration: TimeInterval
+    var ts: Date
+    var byteSize: Int
     var numberOfRecords: Int
     var bucket: String?
     var measurement: String?
@@ -26,8 +26,8 @@ internal struct FXBDataUpload: Codable {
     enum CodingKeys: String, CodingKey {
         case id
         case status
-        case createdAt = "created_at"
-        case duration
+        case ts
+        case byteSize
         case numberOfRecords = "number_of_records"
         case bucket
         case measurement
@@ -35,12 +35,12 @@ internal struct FXBDataUpload: Codable {
     }
 }
 
-extension FXBDataUpload: FetchableRecord, PersistableRecord {
+extension FXBDataUpload: FetchableRecord, MutablePersistableRecord {
     enum Columns {
         static let id = Column(CodingKeys.id)
         static let status = Column(CodingKeys.status)
-        static let createdAt = Column(CodingKeys.createdAt)
-        static let duration = Column(CodingKeys.duration)
+        static let ts = Column(CodingKeys.ts)
+        static let byteSize = Column(CodingKeys.byteSize)
         static let numberOfRecords = Column(CodingKeys.numberOfRecords)
         static let bucket = Column(CodingKeys.bucket)
         static let measurement = Column(CodingKeys.measurement)
@@ -49,11 +49,15 @@ extension FXBDataUpload: FetchableRecord, PersistableRecord {
     
     static var databaseTableName: String = "data_upload"
     
+    mutating func didInsert(_ inserted: InsertionSuccess) {
+        id = inserted.rowID
+    }
+    
     static func create(_ table: TableDefinition) {
         table.autoIncrementedPrimaryKey(CodingKeys.id.stringValue)
         table.column(CodingKeys.status.stringValue, .text)
-        table.column(CodingKeys.createdAt.stringValue, .datetime).defaults(to: Date())
-        table.column(CodingKeys.duration.stringValue, .integer)
+        table.column(CodingKeys.ts.stringValue, .datetime).defaults(to: Date())
+        table.column(CodingKeys.byteSize.stringValue, .integer)
         table.column(CodingKeys.numberOfRecords.stringValue, .integer)
         table.column(CodingKeys.bucket.stringValue, .text)
         table.column(CodingKeys.measurement.stringValue, .text)

--- a/Sources/FlexiBLE/db/tables/FXBDataUpload.swift
+++ b/Sources/FlexiBLE/db/tables/FXBDataUpload.swift
@@ -8,59 +8,73 @@
 import Foundation
 import GRDB
 
-internal enum FXBDataUploadStatus: String, Codable {
-    case success
-    case fail
-}
-
 internal struct FXBDataUpload: Codable {
     var id: Int64?
-    var status: FXBDataUploadStatus
     var ts: Date
-    var byteSize: Int
-    var numberOfRecords: Int
-    var bucket: String?
-    var measurement: String?
+    var tableName: String
+    var database: String
+    var APIURL: String
+    var startDate: Date?
+    var endDate: Date
+    var expectedUploadCount: Int
+    var uploadCount: Int
     var errorMessage: String?
+    var uploadTimeSeconds: TimeInterval
+    var numberOfAPICalls: Int
+    var totalBytes: Int
     
     enum CodingKeys: String, CodingKey {
-        case id
-        case status
-        case ts
-        case byteSize
-        case numberOfRecords = "number_of_records"
-        case bucket
-        case measurement
+        case id, ts
+        case tableName = "table_name"
+        case database
+        case APIURL = "api_url"
+        case startDate = "start_date"
+        case endDate = "end_date"
+        case expectedUploadCount = "expected_upload_count"
+        case uploadCount = "upload_count"
         case errorMessage = "error_message"
+        case uploadTimeSeconds = "upload_time_seconds"
+        case numberOfAPICalls = "number_of_api_calls"
+        case totalBytes = "total_bytes"
     }
 }
 
 extension FXBDataUpload: FetchableRecord, MutablePersistableRecord {
     enum Columns {
         static let id = Column(CodingKeys.id)
-        static let status = Column(CodingKeys.status)
         static let ts = Column(CodingKeys.ts)
-        static let byteSize = Column(CodingKeys.byteSize)
-        static let numberOfRecords = Column(CodingKeys.numberOfRecords)
-        static let bucket = Column(CodingKeys.bucket)
-        static let measurement = Column(CodingKeys.measurement)
+        static let tableName = Column(CodingKeys.tableName)
+        static let database = Column(CodingKeys.database)
+        static let APIURL = Column(CodingKeys.APIURL)
+        static let startDate = Column(CodingKeys.startDate)
+        static let endDate = Column(CodingKeys.endDate)
+        static let expectedUploadCount = Column(CodingKeys.expectedUploadCount)
+        static let uploadCount = Column(CodingKeys.uploadCount)
         static let errorMessage = Column(CodingKeys.errorMessage)
+        static let uploadTimeSeconds = Column(CodingKeys.uploadTimeSeconds)
+        static let numberOfAPICalls = Column(CodingKeys.numberOfAPICalls)
+        static let totalBytes = Column(CodingKeys.totalBytes)
     }
     
     static var databaseTableName: String = "data_upload"
-    
+
     mutating func didInsert(_ inserted: InsertionSuccess) {
         id = inserted.rowID
     }
     
     static func create(_ table: TableDefinition) {
         table.autoIncrementedPrimaryKey(CodingKeys.id.stringValue)
-        table.column(CodingKeys.status.stringValue, .text)
         table.column(CodingKeys.ts.stringValue, .datetime).defaults(to: Date())
-        table.column(CodingKeys.byteSize.stringValue, .integer)
-        table.column(CodingKeys.numberOfRecords.stringValue, .integer)
-        table.column(CodingKeys.bucket.stringValue, .text)
-        table.column(CodingKeys.measurement.stringValue, .text)
+        table.column(CodingKeys.tableName.stringValue, .text)
+        table.column(CodingKeys.database.stringValue, .text)
+        table.column(CodingKeys.APIURL.stringValue, .text)
+        table.column(CodingKeys.startDate.stringValue, .datetime)
+        table.column(CodingKeys.endDate.stringValue, .datetime)
+        table.column(CodingKeys.expectedUploadCount.stringValue, .integer)
+        table.column(CodingKeys.uploadCount.stringValue, .integer)
         table.column(CodingKeys.errorMessage.stringValue, .text)
+        table.column(CodingKeys.uploadTimeSeconds.stringValue, .double)
+        table.column(CodingKeys.numberOfAPICalls.stringValue, .integer)
+        table.column(CodingKeys.totalBytes.stringValue, .integer)
     }
 }

--- a/Sources/FlexiBLE/remote/InfluxDBTableUploader.swift
+++ b/Sources/FlexiBLE/remote/InfluxDBTableUploader.swift
@@ -1,0 +1,163 @@
+//
+//  File.swift
+//  
+//
+//  Created by Blaine Rothrock on 1/11/23.
+//
+
+import Foundation
+
+public class FXBTableUploader {
+    var table: FXBTimeSeriesTable
+    var startDate: Date?
+    var endDate: Date
+    
+    var credentials: InfluxDBCredentials
+    
+    private var calculatedUploadCount = 0
+    var totalRemaining: Int = 0
+    var uploaded: Int = 0
+    
+    var complete: Bool = false
+    var errorMessage: String? = nil
+    
+    private var uploadTime: TimeInterval = 0
+    private var numberOfAPICalls: Int = 0
+    private var totalBytes: Int = 0
+    
+    init(
+        table: FXBTimeSeriesTable,
+        credentials: InfluxDBCredentials,
+        startDate: Date?,
+        endDate: Date
+    ) {
+        self.table = table
+        self.credentials = credentials
+        self.startDate = startDate
+        self.endDate = endDate
+        
+        Task {
+            await calculateRecordCount()
+        }
+    }
+    
+    private func nextRecords() async -> [ILPRecord] {
+        do {
+            return try await table.ILPQuery(
+                from: startDate,
+                to: endDate,
+                uploaded: false,
+                limit: credentials.batchSize,
+                deviceId: credentials.deviceId
+            )
+        } catch {
+            complete = true
+            let message = "error querying records: \(error.localizedDescription)"
+            errorMessage = message
+            uploadLog.error("\(message)")
+            await save()
+            return []
+        }
+    }
+    
+    func upload() async -> Result<Bool, Error> {
+        let start = Date.now
+        
+        var records = await nextRecords()
+        
+        while !records.isEmpty {
+            let res = await records.ship(with: credentials)
+            numberOfAPICalls += 1
+            switch res {
+            case .success(_):
+                
+                totalRemaining -= records.count
+                uploaded += records.count
+                totalBytes += records.reduce(0, { $0 + Data($1.line.utf8).count })
+                
+                await updateUploadedFlag(records: records)
+                
+                records = await nextRecords()
+                
+            case .failure(let error):
+                complete = true
+                errorMessage = error.localizedDescription
+                uploadTime = abs(start.timeIntervalSinceNow)
+                await save()
+                return res
+            }
+        }
+        
+        complete = true
+        if credentials.purgeOnUpload {
+            await purgeUploaded()
+        }
+        uploadTime = abs(start.timeIntervalSinceNow)
+        await save()
+        return .success(true)
+    }
+    
+    private func updateUploadedFlag(records: [ILPRecord]) async {
+        do {
+            try await table.updateUpload(lines: records)
+            uploadLog.info("updated database records")
+        } catch {
+            errorMessage = "error updating uploaded flag: error \(error.localizedDescription)"
+            uploadLog.error("failed to update database records")
+        }
+    }
+    
+    private func purgeUploaded() async {
+        do {
+            try await table.purgeUploadedRecords()
+        } catch {
+            errorMessage = "unable to purge records: \(error.localizedDescription)"
+        }
+    }
+    
+    private func calculateRecordCount() async {
+        do {
+            let st = try await FXBRead().getTotalRecords(
+                for: table.tableName,
+                from: startDate,
+                to: endDate,
+                uploaded: false
+            )
+            if st == 0 { complete = true }
+            totalRemaining = st
+            calculatedUploadCount = st
+            uploaded = 0
+        } catch {
+            totalRemaining = 0
+            uploaded = 0
+            complete = true
+            await save()
+        }
+    }
+    
+    private func save() async {
+        do {
+            try await FXBDBManager.shared.dbQueue.write { [weak self] db in
+                guard let self = self else { return }
+                
+                var record = FXBDataUpload(
+                    ts: Date.now,
+                    tableName: self.table.tableName,
+                    database: "influxDB",
+                    APIURL: self.credentials.url.absoluteString,
+                    startDate: self.startDate,
+                    endDate: self.endDate,
+                    expectedUploadCount: self.calculatedUploadCount,
+                    uploadCount: self.uploaded,
+                    uploadTimeSeconds: self.uploadTime,
+                    numberOfAPICalls: self.numberOfAPICalls,
+                    totalBytes: self.totalBytes
+                )
+                
+                try record.insert(db)
+            }
+        } catch {
+            uploadLog.error("error inserting upload record: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/FlexiBLE/remote/InfluxDBUploader.swift
+++ b/Sources/FlexiBLE/remote/InfluxDBUploader.swift
@@ -9,14 +9,44 @@ import Foundation
 import GRDB
 import os
 
+public class InfluxDBCredentials {
+    public var url: URL
+    public var org: String
+    public var bucket: String
+    internal var token: String
+    public var batchSize: Int
+    public var deviceId: String
+    public var uploadInterval: TimeInterval?
+    public var purgeOnUpload: Bool
+    
+    public init(
+        url: URL,
+        org: String,
+        bucket: String,
+        token: String,
+        batchSize: Int,
+        deviceId: String,
+        purgeOnUpload: Bool,
+        uploadInterval: TimeInterval?
+    ) {
+        self.url = url
+        self.org = org
+        self.bucket = bucket
+        self.token = token
+        self.batchSize = batchSize
+        self.deviceId = deviceId
+        self.purgeOnUpload = purgeOnUpload
+        self.uploadInterval = uploadInterval
+    }
+}
+
 public class InfluxDBUploader: FXBRemoteDatabaseUploader {
+    
     public var state: FXBDataUploaderState
     
     public private(set) var progress: Float
     
     public private (set) var estNumRecs: Int
-    
-    private let logger = Logger(subsystem: "com.blainerothrock.flexible", category: "uploader")
     
     public var totalUploaded: Int {
         didSet {
@@ -26,75 +56,51 @@ public class InfluxDBUploader: FXBRemoteDatabaseUploader {
     
     public private (set) var statusMessage: String
     
-    public var batchSize: Int
-    public var tableStatuses: [FXBTableUploadState]
+    public var tableUploaders: [FXBTableUploader]
     
-    private let url: URL
-    private let org: String
-    private let bucket: String
-    private let token: String
+    private let credentials: InfluxDBCredentials
     
     public let startDate: Date?
-    public let endDate: Date?
-    
-    public let deviceId: String
-    
-    public let purgeOnUpload: Bool
+    public let endDate: Date
     
     public init(
-        url: URL,
-        org: String,
-        bucket: String,
-        token: String,
+        credentials: InfluxDBCredentials,
         startDate: Date?=nil,
-        endDate: Date?=nil,
-        batchSize: Int=2500,
-        deviceId: String,
-        purgeOnUpload: Bool = false
+        endDate: Date=Date.now
     ) {
-        self.url = url
-        self.org = org
-        self.bucket = bucket
-        self.token = token
+        self.credentials = credentials
         self.startDate = startDate
         self.endDate = endDate
-        self.batchSize = batchSize
         self.state = .notStarted
         self.progress = 0.0
         self.estNumRecs = 0
         self.totalUploaded = 0
-        self.deviceId = deviceId
         self.statusMessage = ""
-        self.purgeOnUpload = purgeOnUpload
         
-        tableStatuses = [
-            FXBTableUploadState(table: .experiment),
-            FXBTableUploadState(table: .timestamp),
-            FXBTableUploadState(table: .heartRate),
-            FXBTableUploadState(table: .location)
+        tableUploaders = [
+            FXBTableUploader(table: .experiment, credentials: credentials, startDate: startDate, endDate: endDate),
+            FXBTableUploader(table: .timestamp, credentials: credentials, startDate: startDate, endDate: endDate),
+            FXBTableUploader(table: .heartRate, credentials: credentials, startDate: startDate, endDate: endDate),
+            FXBTableUploader(table: .location, credentials: credentials, startDate: startDate, endDate: endDate),
         ]
     }
     
-    public func start() {
-        Task {
-            do {
-                self.state = .initializing
-                
-                await addDynamicTableStates()
-                
-                let numRemaining = try await calculateRemaining()
-                
-                self.estNumRecs = numRemaining
-                self.state = .running
-            } catch {
-                self.state = .error(msg: "error initializing upload: \(error.localizedDescription)")
-            }
-            
-            do {
-                try await continuousUpload()
-            } catch {
-                self.state = .error(msg: "error in record upload: \(error.localizedDescription)")
-            }
+    public func upload() async -> Result<Bool, Error> {
+        self.state = .initializing
+        
+        await addDynamicTableStates()
+        
+        let numRemaining = tableUploaders.reduce(0, { $0 + $1.totalRemaining })
+        
+        self.estNumRecs = numRemaining
+        self.state = .running
+        
+        do {
+            try await continuousUpload()
+            return .success(true)
+        } catch {
+            self.state = .error(msg: "error in record upload: \(error.localizedDescription)")
+            return .failure(error)
         }
     }
     
@@ -105,123 +111,39 @@ public class InfluxDBUploader: FXBRemoteDatabaseUploader {
     private func addDynamicTableStates() async {
         let dtns = await FXBRead().dynamicTableNames()
         for tn in dtns {
-            if tableStatuses.first(where: { $0.table.tableName == tn }) == nil {
-                tableStatuses.append(FXBTableUploadState(table: .dynamicData(name: "\(tn)_data")))
-                tableStatuses.append(FXBTableUploadState(table: .dynamicConfig(name: "\(tn)_config")))
+            if tableUploaders.first(where: { $0.table.tableName == tn }) == nil {
+                tableUploaders.append(FXBTableUploader(
+                    table: .dynamicData(name: "\(tn)_data"),
+                    credentials: credentials,
+                    startDate: startDate,
+                    endDate: endDate
+                ))
+                tableUploaders.append(FXBTableUploader(
+                    table: .dynamicConfig(name: "\(tn)_config"),
+                    credentials: credentials,
+                    startDate: startDate,
+                    endDate: endDate
+                ))
             }
         }
     }
     
     private func continuousUpload() async throws {
         while self.state == .running {
-            if let tableStatus = tableStatuses.first(where: { $0.totalRemaining > 0 }) {
-                DispatchQueue.main.async {
-                    self.statusMessage = "Uploading \(tableStatus.table.tableName) ..."
+            
+            for uploader in tableUploaders {
+                guard !uploader.complete else { continue }
+                let res = await uploader.upload()
+                switch res {
+                case .success(_): continue
+                case .failure(let error):
+                    self.statusMessage = error.localizedDescription
+                    // self.state = .error(msg: error.localizedDescription)
                 }
                 
-                do {
-                    logger.info("starting upload for \(tableStatus.table.tableName)")
-                    let records = try await tableStatus.table.ILPQuery(
-                        from: startDate,
-                        to: endDate,
-                        uploaded: false,
-                        limit: batchSize,
-                        deviceId: deviceId
-                    )
-                    logger.info("\(records.count) records found")
-                    
-                    if records.count == 0 {
-                        tableStatus.totalRemaining = 0
-                    }
-                    
-                    let success = try await records.ship(
-                        url: url,
-                        org: org,
-                        bucket: bucket,
-                        token: token
-                    )
-                    
-                    logger.info("upload success?: \(success)")
-                    
-                    guard success else {
-                        self.state = .error(msg: "unable to upload records")
-                        let _ = try await FXBWrite().recordUpload(
-                            success: false,
-                            byteSize: 0,
-                            numberOfRecords: records.count,
-                            bucket: self.bucket,
-                            measurement: records.first?.measurement ?? tableStatus.table.tableName,
-                            errorMessage: "unable to upload records"
-                        )
-                        tableStatus.totalRemaining = 0
-                        return
-                    }
-                    
-                    if records.count > 0 {
-                        await updateUploaded(records: records, tableStatus: tableStatus)
-                        let _ = try await FXBWrite().recordUpload(
-                            success: true,
-                            byteSize: records.reduce(0, { $0 + $1.line.lengthOfBytes(using: .utf8) }),
-                            numberOfRecords: records.count,
-                            bucket: bucket,
-                            measurement: records.first?.measurement ?? tableStatus.table.tableName,
-                            errorMessage: nil
-                        )
-                    } else {
-                        tableStatus.totalRemaining = 0
-                    }
-                    
-                } catch {
-                    self.state = .error(msg: "error querying records for \(tableStatus.table.tableName): error \(error.localizedDescription)")
-                    let _ = try? await FXBWrite().recordUpload(
-                        success: false,
-                        byteSize: 0,
-                        numberOfRecords: 0,
-                        bucket: nil,
-                        measurement: nil,
-                        errorMessage: "error querying records for \(tableStatus.table.tableName): error \(error.localizedDescription)"
-                    )
-                    tableStatus.totalRemaining = 0
-                }
-            } else {
-                self.state = .done
-            }
-        }
-    }
-    
-    private func updateUploaded(records: [ILPRecord], tableStatus: FXBTableUploadState) async {
-        do {
-            try await tableStatus.table.updateUpload(lines: records)
-            
-            if purgeOnUpload {
-                try await tableStatus.table.purgeUploadedRecords()
             }
             
-            tableStatus.uploaded += records.count
-            tableStatus.totalRemaining -= records.count
-            
-            self.totalUploaded += records.count
-            
-            logger.info("updated database records")
-        } catch {
-            self.state = .error(msg: "error updating uploaded state for \(tableStatus.table.tableName): error \(error.localizedDescription)")
-            logger.error("failed to update database records")
+            self.state = .done
         }
-    }
-    
-    private func calculateRemaining() async throws -> Int{
-        var tmpTotal = 0
-        for status in tableStatuses {
-            let st = try await FXBRead().getTotalRecords(
-                for: status.table.tableName,
-                from: startDate,
-                to: endDate,
-                uploaded: false
-            )
-            status.totalRemaining = st
-            tmpTotal += st
-        }
-        
-        return tmpTotal
     }
 }

--- a/Sources/FlexiBLE/remote/InfluxLineProtocol.swift
+++ b/Sources/FlexiBLE/remote/InfluxLineProtocol.swift
@@ -89,7 +89,9 @@ extension Array where Element == ILPRecord {
         req.setValue("application/json", forHTTPHeaderField: "Accept")
         req.httpBody = self.map({ $0.line }).joined(separator: "\n").data(using: .utf8)
         
-        guard self.count > 0 else { return false }
+        guard self.count > 0 else {
+            return true
+        }
         
         webLog.debug("uploading records, sample: \(self[0].line)")
         
@@ -99,7 +101,7 @@ extension Array where Element == ILPRecord {
             return false
         }
         if (200...299).contains(httpRes.statusCode) {
-            webLog.info("successful influx upload: \(httpRes.statusCode)")
+            webLog.info("successful influx upload for \(self.first?.measurement ?? "--unknown--"), count: \(self.count): \(httpRes.statusCode)")
             return true
         } else {
             webLog.error("error: \(String(data: data, encoding: .utf8) ?? "--unknown--")")

--- a/Sources/FlexiBLE/remote/InfluxLineProtocol.swift
+++ b/Sources/FlexiBLE/remote/InfluxLineProtocol.swift
@@ -71,42 +71,66 @@ internal class ILPRecord {
     }
 }
 
+enum InfluxDBUploadError: Error {
+    case invalidURL
+    case unknownHttpResult
+    case httpError(statusCode: Int, message: String)
+}
+
+extension InfluxDBUploadError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL: return "Invalild Influx URL"
+        case .unknownHttpResult: return "Unable to parse HTTP response"
+        case .httpError(let statusCode, let message):
+            return "HTTP Error (\(statusCode)): \(message)"
+        }
+    }
+}
+
 extension Array where Element == ILPRecord {
-    func ship(url baseURL: URL, org: String, bucket: String, token: String) async throws -> Bool {
-        var urlComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+    func ship(with credentials: InfluxDBCredentials) async -> Result<Bool, Error> {
+        var urlComponents = URLComponents(url: credentials.url, resolvingAgainstBaseURL: false)
         urlComponents?.queryItems = [
-            URLQueryItem(name: "org", value: org),
-            URLQueryItem(name: "bucket", value: bucket)
+            URLQueryItem(name: "org", value: credentials.org),
+            URLQueryItem(name: "bucket", value: credentials.bucket)
         ]
         guard let url = urlComponents?.url else {
-            return false
+            return .failure(InfluxDBUploadError.invalidURL)
         }
 
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
-        req.setValue("Token \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue("Token \(credentials.token)", forHTTPHeaderField: "Authorization")
         req.setValue("text/plain; charset=utf-8", forHTTPHeaderField: "Content-Type")
         req.setValue("application/json", forHTTPHeaderField: "Accept")
         req.httpBody = self.map({ $0.line }).joined(separator: "\n").data(using: .utf8)
         
         guard self.count > 0 else {
-            return true
+            return .success(true)
         }
         
         webLog.debug("uploading records, sample: \(self[0].line)")
         
-        let (data, res) = try await URLSession.shared.data(for: req)
-
-        guard let httpRes = res as? HTTPURLResponse else {
-            return false
+        do {
+            let (data, res) = try await URLSession.shared.data(for: req)
+            
+            guard let httpRes = res as? HTTPURLResponse else {
+                return .failure(InfluxDBUploadError.unknownHttpResult)
+            }
+            
+            if (200...299).contains(httpRes.statusCode) {
+                webLog.info("successful influx upload for \(self.first?.measurement ?? "--unknown--"), count: \(self.count): \(httpRes.statusCode)")
+                return .success(true)
+            } else {
+                let responseMessage = String(data: data, encoding: .utf8) ?? "--unknown--"
+                webLog.error("error: \(responseMessage)")
+                return .failure(InfluxDBUploadError.httpError(statusCode: httpRes.statusCode, message: responseMessage))
+            }
+        } catch {
+            return .failure(error)
         }
-        if (200...299).contains(httpRes.statusCode) {
-            webLog.info("successful influx upload for \(self.first?.measurement ?? "--unknown--"), count: \(self.count): \(httpRes.statusCode)")
-            return true
-        } else {
-            webLog.error("error: \(String(data: data, encoding: .utf8) ?? "--unknown--")")
-        }
 
-        return false
+        
     }
 }

--- a/Sources/FlexiBLE/remote/RemoteDatabaseUploader.swift
+++ b/Sources/FlexiBLE/remote/RemoteDatabaseUploader.swift
@@ -45,57 +45,15 @@ public enum FXBDataUploaderState {
     }
 }
 
-//public protocol FXBRemoteDatabaseUploader: ObservableObject {
-//    var state: FXBDataUploaderState { get }
-//    var stateValue: Published<FXBDataUploaderState> { get }
-//    var statePublisher: Published<FXBDataUploaderState>.Publisher { get }
-//
-//    var progress: Float { get }
-//    var progressValue: Published<Float> { get }
-//    var progressPublisher: Published<Float>.Publisher { get }
-//
-//    var estNumRecs: Int { get }
-//    var estNumRecsValue: Published<Int> { get }
-//    var estNumRecsPublisher: Published<Int>.Publisher { get }
-//
-//    var totalUploaded: Int { get }
-//    var totalUploadedValue: Published<Int> { get }
-//    var totalUploadedPublisher: Published<Int>.Publisher { get }
-//
-//    var batchSize: Int { get }
-//    var tableStatuses: [FXBTableUploadState] { get }
-//
-//
-//    func start()
-//    func pause()
-//}
-
 public protocol FXBRemoteDatabaseUploader {
     var state: FXBDataUploaderState { get }
     var progress: Float { get }
     var estNumRecs: Int { get }
     var totalUploaded: Int { get }
-    var batchSize: Int { get }
-    var tableStatuses: [FXBTableUploadState] { get }
+    var tableUploaders: [FXBTableUploader] { get }
     var statusMessage: String { get }
     
     
-    func start()
+    func upload() async -> Result<Bool, Error>
     func pause()
-}
-
-public class FXBTableUploadState {
-    var table: FXBTimeSeriesTable
-    var startDate: Date?
-    var endDate: Date?
-    var totalRemaining: Int
-    var uploaded: Int
-    
-    init(table: FXBTimeSeriesTable) {
-        self.table = table
-        self.startDate = nil
-        self.endDate = nil
-        self.totalRemaining = 0
-        self.uploaded = 0
-    }
 }

--- a/Sources/FlexiBLE/remote/StaticTimeSeriesTable.swift
+++ b/Sources/FlexiBLE/remote/StaticTimeSeriesTable.swift
@@ -242,7 +242,7 @@ extension FXBTimeSeriesTable {
                   let ts = Date.fromSQLString(tsStr),
                   let deviceName: String = rec.getValue(for: "device"),
                   let spec = specs[specId],
-                  let device = spec.devices.first(where: { $0.name == deviceName }),
+                  let device = spec.devices.first(where: { deviceName.starts(with: $0.name) }),
                   let measurement = device.dataStreams.first(where: { $0.name == name.replacingOccurrences(of: "_config", with: "") }) else {
                 continue
             }

--- a/Sources/FlexiBLE/remote/StaticTimeSeriesTable.swift
+++ b/Sources/FlexiBLE/remote/StaticTimeSeriesTable.swift
@@ -465,4 +465,15 @@ extension FXBTimeSeriesTable {
             try db.execute(sql: q)
         }
     }
+    
+    func purgeUploadedRecords() async throws {
+        try await FXBDBManager.shared.dbQueue.write { db in
+            let q = """
+                DELETE FROM \(tableName)
+                WHERE uploaded = true
+            """
+        
+            try db.execute(sql: q)
+        }
+    }
 }

--- a/Sources/FlexiBLE/remote/StaticTimeSeriesTable.swift
+++ b/Sources/FlexiBLE/remote/StaticTimeSeriesTable.swift
@@ -152,24 +152,6 @@ extension FXBTimeSeriesTable {
                         }
                     }
                 }
-//                switch dv.type {
-//                case .float:
-//                    if let v: Float = rec.getValue(for: dv.name) {
-//                        ilp.field(dv.name, float: v)
-//                    }
-//                case .int:
-//                    if let v: Int = rec.getValue(for: dv.name) {
-//                        ilp.field(dv.name, int: v)
-//                    }
-//                case .string:
-//                    if let v: String = rec.getValue(for: dv.name) {
-//                        ilp.field(dv.name, str: v)
-//                    }
-//                case .unsignedInt:
-//                    if let v: UInt = rec.getValue(for: dv.name) {
-//                        ilp.field(dv.name, uint: v)
-//                    }
-//                }
             }
             
             ilps.append(ilp)

--- a/Sources/FlexiBLE/utilities/FXB+Logger.swift
+++ b/Sources/FlexiBLE/utilities/FXB+Logger.swift
@@ -22,3 +22,5 @@ internal let webLog = Logger(subsystem: "com.blainerothrock.flexible", category:
 
 /// temp developmental logging
 internal let devLog = Logger(subsystem: "com.blainerothrock.flexible", category: "dev")
+
+let uploadLog = Logger(subsystem: "com.blainerothrock.flexible", category: "uploader")


### PR DESCRIPTION
closes #20 

The upload logic is drastically simplified. 
* new `InfluxDBCredentials` class to hold the detail of an influxdb upload (which is the only supported remote database)
* refactored `FXBDataUpload` database table records, which contains more details on upload statues
* `FXBTableUploader` replaces the table state class, now holds most of the upload logic, including handling batches, and saving upload records. 
* `InfluxDBUploader` is simplied to manage a list of `FXBTableUploader`