### PR TITLE
Hot Fix: Issues when loading latest data stream configuration with multiple devices

### DIFF
--- a/Sources/FlexiBLE/bluetooth/DataStreamHandler.swift
+++ b/Sources/FlexiBLE/bluetooth/DataStreamHandler.swift
@@ -247,7 +247,7 @@ extension FXBDataStreamConfig {
         case .float:
             switch self.size {
             case 2:
-                var val = Float16(value) ?? Float16(defaultValue) ?? Float16(0)
+                var val = Float(value) ?? Float(defaultValue) ?? Float(0)
                 withUnsafePointer(to: &val) {
                     data.append(UnsafeBufferPointer(start: $0, count: 1))
                 }

--- a/Sources/FlexiBLE/db/FXBDBManager.swift
+++ b/Sources/FlexiBLE/db/FXBDBManager.swift
@@ -216,12 +216,13 @@ public final class FXBDBManager {
         return data
     }
     
-    public func config(for ds: FXBDataStream) async -> GenericRow? {
+    public func config(for ds: FXBDataStream, deviceName: String) async -> GenericRow? {
         let tableName = "\(tableName(from: ds.name))_config"
         
         let sql = """
             SELECT \(ds.configValues.map({ $0.name }).joined(separator: ", "))
             FROM \(tableName)
+            WHERE device = :deviceName
             ORDER BY ts DESC
             LIMIT 1;
         """
@@ -231,7 +232,7 @@ public final class FXBDBManager {
                 let pragma = try Row.fetchAll(db, sql: "PRAGMA table_info(\(tableName));")
                 let info = pragma.map({ FXBTableInfo.make(from: $0) })
                     
-                let result = try Row.fetchOne(db, sql: sql)
+                let result = try Row.fetchOne(db, sql: sql, arguments: ["deviceName": deviceName])
                 return result.map({ GenericRow(metadata: info, row: $0) })
             }
         } catch {

--- a/Sources/FlexiBLE/db/FXBRead.swift
+++ b/Sources/FlexiBLE/db/FXBRead.swift
@@ -94,11 +94,12 @@ public struct FXBRead {
                 // query for latest record
                 let q = """
                     SELECT * FROM \(dataStreamName)_config
+                    WHERE device = :deviceName
                     ORDER BY ts DESC
                     LIMIT 1
                 """
                 
-                guard let configRow = try Row.fetchOne(db, sql: q) else {
+                guard let configRow = try Row.fetchOne(db, sql: q, arguments: ["deviceName": deviceName]) else {
                     pLog.info("no latest config record found for \(dataStreamName)")
                     return nil
                 }


### PR DESCRIPTION
* A Device name is now required when querying data stream configurations.
* MacOS catalyst support (removing `Float16` use)

closes #22 
